### PR TITLE
First can't be used on nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gem
+test/setup/tmdb_api_key.txt

--- a/lib/ruby-tmdb/tmdb.rb
+++ b/lib/ruby-tmdb/tmdb.rb
@@ -26,11 +26,11 @@ class Tmdb
     url = Tmdb.base_api_url + method + '/' + language + '/json/' + Tmdb.api_key + '/' + CGI::escape(data.to_s)
     response = Tmdb.get_url(url)
     if(response.code.to_i != 200)
-      return nil
+      return []
     end
     body = JSON(response.body)
     if( body.first.include?("Nothing found"))
-      return nil
+      return []
     else
       return body
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 TEST_LIVE_API = false
 
 require 'rubygems'
+require 'mocha'
 require 'test/unit'
 
 unless(TEST_LIVE_API)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,6 @@
 TEST_LIVE_API = false
 
 require 'rubygems'
-require 'mocha'
 require 'test/unit'
 
 unless(TEST_LIVE_API)

--- a/test/unit/tmdb_test.rb
+++ b/test/unit/tmdb_test.rb
@@ -99,14 +99,14 @@ class TmdbTest < Test::Unit::TestCase
   
   test "failed API call should return nil" do
     movies = Tmdb.api_call('Movie.blarg', 'Transformers')
-    assert_kind_of NilClass, movies
-    assert_nil movies
+    assert_kind_of Array, movies
+    assert_empty movies
   end
   
   test "API call that finds no results should return nil" do
     movies = Tmdb.api_call('Search.empty', 'Transformers')
-    assert_kind_of NilClass, movies
-    assert_nil movies
+    assert_kind_of Array, movies
+    assert_empty movies
   end
   
   test "API call cache should not be changed when data altered in the receiving method" do


### PR DESCRIPTION
Sorry, I could not come up with a better title for the pull request.

Anyway.
If the TMDb server it self returns a status code that isn't 200 the [api_call](https://github.com/aarongough/ruby-tmdb/blob/master/lib/ruby-tmdb/tmdb.rb#L29) method returns nil. 

One of the methods that uses the retuned value is the [new method](https://github.com/aarongough/ruby-tmdb/blob/master/lib/ruby-tmdb/tmdb_movie.rb#L39), it applies the `first` method on the returned object, as you can see [here](https://github.com/oleander/ruby-tmdb/blob/master/lib/ruby-tmdb/tmdb_movie.rb#L42).

This causes the script to crash.

The solution is to always return a list, as I did in the [second commit](https://github.com/oleander/ruby-tmdb/commit/9ce1aedb820935c5b9629dc29754d43134b3257c).

I had some difficulties to write a failing test for the bug, due to my lack of experience with Test Unit.
(I'm more of a rspec guy :)).

I hope it's okey anyway.
